### PR TITLE
refactor: Streamline LoggerBase interface

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/include/nealog/Logger.h
+++ b/include/nealog/Logger.h
@@ -26,20 +26,8 @@ namespace nealog
       public:
         Logger(const std::string& name) noexcept;
 
-      public:
-        auto addSink(const Sink::SPtr&) -> void override;
-        auto log(Severity, const std::string_view& message) -> void override;
-
-        auto trace(const std::string_view& message) -> void override;
-        auto debug(const std::string_view& message) -> void override;
-        auto info(const std::string_view& message) -> void override;
-        auto warn(const std::string_view& message) -> void override;
-        auto error(const std::string_view& message) -> void override;
-        auto fatal(const std::string_view& message) -> void override;
-
       private:
-        auto setParent() -> void;
-        auto writeToSinks(Severity, const std::string_view& message) -> void;
+        auto setParent() -> void;        
     };
 
 

--- a/include/nealog/Logger.h
+++ b/include/nealog/Logger.h
@@ -26,8 +26,28 @@ namespace nealog
       public:
         Logger(const std::string& name) noexcept;
 
+      public:
+        virtual auto addSink(const Sink::SPtr&) -> void override;
+        virtual auto log(Severity, const std::string_view& message) -> void override;
+        virtual auto getSinks() -> const std::vector<Sink::SPtr> override;
+        virtual auto trace(const std::string_view& message) -> void override;
+        virtual auto debug(const std::string_view& message) -> void override;
+        virtual auto info(const std::string_view& message) -> void override;
+        virtual auto warn(const std::string_view& message) -> void override;
+        virtual auto error(const std::string_view& message) -> void override;
+        virtual auto fatal(const std::string_view& message) -> void override;
+
+      protected:
+        virtual auto writeToSinks(Severity, const std::string_view& message) -> void override;
+        virtual auto setParent(LoggerBase::SPtr parent) -> void override;
+
       private:
-        auto setParent() -> void;        
+        auto setParent() -> void;
+
+      protected:
+        std::vector<Sink::SPtr> sinks_{};
+        SPtr parent_ = nullptr;
+        std::string name_{};
     };
 
 

--- a/include/nealog/Logger.h
+++ b/include/nealog/Logger.h
@@ -26,8 +26,28 @@ namespace nealog
       public:
         Logger(const std::string& name) noexcept;
 
+      public:
+        auto addSink(const Sink::SPtr&) -> void override;
+        auto log(Severity, const std::string_view& message) -> void override;
+        auto getSinks() -> const std::vector<Sink::SPtr> override;
+        auto trace(const std::string_view& message) -> void override;
+        auto debug(const std::string_view& message) -> void override;
+        auto info(const std::string_view& message) -> void override;
+        auto warn(const std::string_view& message) -> void override;
+        auto error(const std::string_view& message) -> void override;
+        auto fatal(const std::string_view& message) -> void override;
+
+      protected:
+        auto writeToSinks(Severity, const std::string_view& message) -> void override;
+        auto setParent(LoggerBase::SPtr parent) -> void override;
+
       private:
-        auto setParent() -> void;        
+        auto setParent() -> void;
+
+      protected:
+        std::vector<Sink::SPtr> sinks_{};
+        SPtr parent_ = nullptr;
+        std::string name_{};
     };
 
 

--- a/include/nealog/LoggerBase.h
+++ b/include/nealog/LoggerBase.h
@@ -25,19 +25,20 @@ namespace nealog
         auto operator=(LoggerBase&&) -> LoggerBase&      = default;
 
       public:
-        virtual auto addSink(const Sink::SPtr&) -> void                     = 0;
-        virtual auto log(Severity, const std::string_view& message) -> void = 0;
+        virtual auto addSink(const Sink::SPtr&) -> void;
+        virtual auto log(Severity, const std::string_view& message) -> void;
 
-      public:
+      public:  
         auto getSinks() -> const std::vector<Sink::SPtr>;
-        virtual auto trace(const std::string_view& message) -> void = 0;
-        virtual auto debug(const std::string_view& message) -> void = 0;
-        virtual auto info(const std::string_view& message) -> void  = 0;
-        virtual auto warn(const std::string_view& message) -> void  = 0;
-        virtual auto error(const std::string_view& message) -> void = 0;
-        virtual auto fatal(const std::string_view& message) -> void = 0;
+        auto trace(const std::string_view& message) -> void;
+        auto debug(const std::string_view& message) -> void;
+        auto info(const std::string_view& message) -> void;
+        auto warn(const std::string_view& message) -> void;
+        auto error(const std::string_view& message) -> void;
+        auto fatal(const std::string_view& message) -> void;
 
       protected:
+        auto writeToSinks(Severity, const std::string_view& message) -> void;
         auto setParent(LoggerBase::SPtr parent) -> void;
 
       protected:
@@ -45,4 +46,4 @@ namespace nealog
         SPtr parent_ = nullptr;
         std::string name_{};
     };
-}
+} // namespace nealog

--- a/include/nealog/LoggerBase.h
+++ b/include/nealog/LoggerBase.h
@@ -25,25 +25,18 @@ namespace nealog
         auto operator=(LoggerBase&&) -> LoggerBase&      = default;
 
       public:
-        virtual auto addSink(const Sink::SPtr&) -> void;
-        virtual auto log(Severity, const std::string_view& message) -> void;
-
-      public:  
-        auto getSinks() -> const std::vector<Sink::SPtr>;
-        auto trace(const std::string_view& message) -> void;
-        auto debug(const std::string_view& message) -> void;
-        auto info(const std::string_view& message) -> void;
-        auto warn(const std::string_view& message) -> void;
-        auto error(const std::string_view& message) -> void;
-        auto fatal(const std::string_view& message) -> void;
+        virtual auto addSink(const Sink::SPtr&) -> void                     = 0;
+        virtual auto log(Severity, const std::string_view& message) -> void = 0;
+        virtual auto getSinks() -> const std::vector<Sink::SPtr>            = 0;
+        virtual auto trace(const std::string_view& message) -> void         = 0;
+        virtual auto debug(const std::string_view& message) -> void         = 0;
+        virtual auto info(const std::string_view& message) -> void          = 0;
+        virtual auto warn(const std::string_view& message) -> void          = 0;
+        virtual auto error(const std::string_view& message) -> void         = 0;
+        virtual auto fatal(const std::string_view& message) -> void         = 0;
 
       protected:
-        auto writeToSinks(Severity, const std::string_view& message) -> void;
-        auto setParent(LoggerBase::SPtr parent) -> void;
-
-      protected:
-        std::vector<Sink::SPtr> sinks_{};
-        SPtr parent_ = nullptr;
-        std::string name_{};
+        virtual auto writeToSinks(Severity, const std::string_view& message) -> void = 0;
+        virtual auto setParent(LoggerBase::SPtr parent) -> void                      = 0;
     };
 } // namespace nealog

--- a/include/nealog/LoggerBase.h
+++ b/include/nealog/LoggerBase.h
@@ -16,34 +16,27 @@ namespace nealog
       public:
         virtual ~LoggerBase() = default;
         LoggerBase()          = default;
+        
+        // make it non-copyable and non-assignable
+        LoggerBase(const LoggerBase&) = delete;
+        LoggerBase(LoggerBase&&)      = delete;
 
-      private:
-        LoggerBase(const LoggerBase&) = default;
-        LoggerBase(LoggerBase&&)      = default;
-
-        auto operator=(const LoggerBase&) -> LoggerBase& = default;
-        auto operator=(LoggerBase&&) -> LoggerBase&      = default;
+        auto operator=(const LoggerBase&) -> LoggerBase& = delete;
+        auto operator=(LoggerBase&&) -> LoggerBase&      = delete;
 
       public:
-        virtual auto addSink(const Sink::SPtr&) -> void;
-        virtual auto log(Severity, const std::string_view& message) -> void;
-
-      public:  
-        auto getSinks() -> const std::vector<Sink::SPtr>;
-        auto trace(const std::string_view& message) -> void;
-        auto debug(const std::string_view& message) -> void;
-        auto info(const std::string_view& message) -> void;
-        auto warn(const std::string_view& message) -> void;
-        auto error(const std::string_view& message) -> void;
-        auto fatal(const std::string_view& message) -> void;
+        virtual auto addSink(const Sink::SPtr&) -> void                     = 0;
+        virtual auto log(Severity, const std::string_view& message) -> void = 0;
+        virtual auto getSinks() -> const std::vector<Sink::SPtr>            = 0;
+        virtual auto trace(const std::string_view& message) -> void         = 0;
+        virtual auto debug(const std::string_view& message) -> void         = 0;
+        virtual auto info(const std::string_view& message) -> void          = 0;
+        virtual auto warn(const std::string_view& message) -> void          = 0;
+        virtual auto error(const std::string_view& message) -> void         = 0;
+        virtual auto fatal(const std::string_view& message) -> void         = 0;
 
       protected:
-        auto writeToSinks(Severity, const std::string_view& message) -> void;
-        auto setParent(LoggerBase::SPtr parent) -> void;
-
-      protected:
-        std::vector<Sink::SPtr> sinks_{};
-        SPtr parent_ = nullptr;
-        std::string name_{};
+        virtual auto writeToSinks(Severity, const std::string_view& message) -> void = 0;
+        virtual auto setParent(LoggerBase::SPtr parent) -> void                      = 0;
     };
 } // namespace nealog

--- a/include/nealog_impl/LoggerImpl.h
+++ b/include/nealog_impl/LoggerImpl.h
@@ -14,26 +14,33 @@
 namespace nealog
 {
 
+
     /******************************
-     * LoggerBase
+     * Logger
      ******************************/
     // {{{
 
-    NL_INLINE auto LoggerBase::getSinks() -> const std::vector<Sink::SPtr>
+    NL_INLINE Logger::Logger(const std::string& name) noexcept
+    {
+        name_ = name;
+    }
+
+
+    NL_INLINE auto Logger::getSinks() -> const std::vector<Sink::SPtr>
     {
         return sinks_;
     }
 
 
 
-    NL_INLINE auto LoggerBase::addSink(const Sink::SPtr& sink) -> void
+    NL_INLINE auto Logger::addSink(const Sink::SPtr& sink) -> void
     {
         sinks_.emplace_back(sink);
     }
 
 
 
-    NL_INLINE auto LoggerBase::log(Severity messageSeverity, const std::string_view& message) -> void
+    NL_INLINE auto Logger::log(Severity messageSeverity, const std::string_view& message) -> void
     {
         if (sinks_.empty())
         {
@@ -49,7 +56,7 @@ namespace nealog
 
 
 
-    NL_INLINE auto LoggerBase::writeToSinks(Severity severity, const std::string_view& message) -> void
+    NL_INLINE auto Logger::writeToSinks(Severity severity, const std::string_view& message) -> void
     {
         for (Sink::SPtr& sink : sinks_)
         {
@@ -59,65 +66,52 @@ namespace nealog
 
 
 
-    NL_INLINE auto LoggerBase::trace(const std::string_view& message) -> void
+    NL_INLINE auto Logger::trace(const std::string_view& message) -> void
     {
         log(Severity::Trace, message);
     }
 
 
 
-    NL_INLINE auto LoggerBase::debug(const std::string_view& message) -> void
+    NL_INLINE auto Logger::debug(const std::string_view& message) -> void
     {
         log(Severity::Debug, message);
     }
 
 
 
-    NL_INLINE auto LoggerBase::info(const std::string_view& message) -> void
+    NL_INLINE auto Logger::info(const std::string_view& message) -> void
     {
         log(Severity::Info, message);
     }
 
 
 
-    NL_INLINE auto LoggerBase::warn(const std::string_view& message) -> void
+    NL_INLINE auto Logger::warn(const std::string_view& message) -> void
     {
         log(Severity::Warn, message);
     }
 
 
 
-    NL_INLINE auto LoggerBase::error(const std::string_view& message) -> void
+    NL_INLINE auto Logger::error(const std::string_view& message) -> void
     {
         log(Severity::Error, message);
     }
 
 
 
-    NL_INLINE auto LoggerBase::fatal(const std::string_view& message) -> void
+    NL_INLINE auto Logger::fatal(const std::string_view& message) -> void
     {
         log(Severity::Fatal, message);
     }
 
 
 
-    NL_INLINE auto LoggerBase::setParent(LoggerBase::SPtr parent) -> void
+    NL_INLINE auto Logger::setParent(LoggerBase::SPtr parent) -> void
     {
         parent_ = parent;
     }
-    // }}}
-
-
-
-    /******************************
-     * Logger
-     ******************************/
-    // {{{
-
-    NL_INLINE Logger::Logger(const std::string& name) noexcept
-    {
-        name_ = name;
-    }    
     // }}}
 
 

--- a/include/nealog_impl/LoggerImpl.h
+++ b/include/nealog_impl/LoggerImpl.h
@@ -26,6 +26,81 @@ namespace nealog
 
 
 
+    NL_INLINE auto LoggerBase::addSink(const Sink::SPtr& sink) -> void
+    {
+        sinks_.emplace_back(sink);
+    }
+
+
+
+    NL_INLINE auto LoggerBase::log(Severity messageSeverity, const std::string_view& message) -> void
+    {
+        if (sinks_.empty())
+        {
+            parent_->log(messageSeverity, message);
+            return;
+        }
+
+        if (messageSeverity >= severity_)
+        {
+            writeToSinks(messageSeverity, message);
+        }
+    }
+
+
+
+    NL_INLINE auto LoggerBase::writeToSinks(Severity severity, const std::string_view& message) -> void
+    {
+        for (Sink::SPtr& sink : sinks_)
+        {
+            sink->write(severity, message);
+        }
+    }
+
+
+
+    NL_INLINE auto LoggerBase::trace(const std::string_view& message) -> void
+    {
+        log(Severity::Trace, message);
+    }
+
+
+
+    NL_INLINE auto LoggerBase::debug(const std::string_view& message) -> void
+    {
+        log(Severity::Debug, message);
+    }
+
+
+
+    NL_INLINE auto LoggerBase::info(const std::string_view& message) -> void
+    {
+        log(Severity::Info, message);
+    }
+
+
+
+    NL_INLINE auto LoggerBase::warn(const std::string_view& message) -> void
+    {
+        log(Severity::Warn, message);
+    }
+
+
+
+    NL_INLINE auto LoggerBase::error(const std::string_view& message) -> void
+    {
+        log(Severity::Error, message);
+    }
+
+
+
+    NL_INLINE auto LoggerBase::fatal(const std::string_view& message) -> void
+    {
+        log(Severity::Fatal, message);
+    }
+
+
+
     NL_INLINE auto LoggerBase::setParent(LoggerBase::SPtr parent) -> void
     {
         parent_ = parent;
@@ -42,83 +117,7 @@ namespace nealog
     NL_INLINE Logger::Logger(const std::string& name) noexcept
     {
         name_ = name;
-    }
-
-
-
-    NL_INLINE auto Logger::addSink(const Sink::SPtr& sink) -> void
-    {
-        sinks_.emplace_back(sink);
-    }
-
-
-
-    NL_INLINE auto Logger::log(Severity messageSeverity, const std::string_view& message) -> void
-    {
-        if (sinks_.empty())
-        {
-            parent_->log(messageSeverity, message);
-            return;
-        }
-
-        if (messageSeverity >= severity_)
-        {
-            writeToSinks(messageSeverity, message);
-        }
-    }
-
-
-
-    NL_INLINE auto Logger::writeToSinks(Severity severity, const std::string_view& message) -> void
-    {
-        for (Sink::SPtr& sink : sinks_)
-        {
-            sink->write(severity, message);
-        }
-    }
-
-
-
-    NL_INLINE auto Logger::trace(const std::string_view& message) -> void
-    {
-        log(Severity::Trace, message);
-    }
-
-
-
-    NL_INLINE auto Logger::debug(const std::string_view& message) -> void
-    {
-        log(Severity::Debug, message);
-    }
-
-
-
-    NL_INLINE auto Logger::info(const std::string_view& message) -> void
-    {
-        log(Severity::Info, message);
-    }
-
-
-
-    NL_INLINE auto Logger::warn(const std::string_view& message) -> void
-    {
-        log(Severity::Warn, message);
-    }
-
-
-
-    NL_INLINE auto Logger::error(const std::string_view& message) -> void
-    {
-        log(Severity::Error, message);
-    }
-
-
-
-    NL_INLINE auto Logger::fatal(const std::string_view& message) -> void
-    {
-        log(Severity::Fatal, message);
-    }
-
+    }    
     // }}}
 
 


### PR DESCRIPTION
Since the logging behaviour and interface for all loggers is probably the same. The interface and functionalty for it should reside in the base class.